### PR TITLE
added issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,28 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes: 
+      value: "By submitting a bug report you can help us make GoBlocks better."
+  - type: input
+    attributes: 
+      label: "Minecraft Version"
+      description: "The minecraft version you used, when the bug occured."
+      placeholder: "1.xx"
+  - type: checkboxes
+    attributes: 
+      label: "Have you tried the following already?"
+      options: 
+        - label: "Reloading the datapack (`/reload`)"
+        - label: "Restarting Minecraft"
+        - label: "using the lates version of GoBlocks"
+  - type: textarea
+    attributes: 
+      label: Decsribe the bug
+      description: Describe the bug you found.
+      placeholder: "What happened:\n[...]\n\nWhat should have happened instead:\n[...]"
+  - type: markdown
+    attributes: 
+      value: "Thanks for contributing!"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,6 +23,14 @@ body:
       label: Decsribe the bug
       description: Describe the bug you found.
       placeholder: "What happened:\n[...]\n\nWhat should have happened instead:\n[...]"
+  - type: textarea
+    attributes: 
+      label: Screenshots
+      description: Optional Screenshots that help describing the bug.
+  - type: textarea
+    attributes: 
+      label: Logs
+      description: Optional relevant game log or error message 
   - type: markdown
     attributes: 
       value: "Thanks for contributing!"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -20,17 +20,17 @@ body:
         - label: "using the latest version of GoBlocks"
   - type: textarea
     attributes: 
-      label: Decsribe the bug
-      description: Describe the bug you found.
+      label: "Describe the bug"
+      description: "Describe the bug you found."
       placeholder: "What happened:\n[...]\n\nWhat should have happened instead:\n[...]"
   - type: textarea
     attributes: 
-      label: Screenshots
-      description: Optional screenshots that help describing the bug.
+      label: "Screenshots"
+      description: "Optional screenshots that help describing the bug."
   - type: textarea
     attributes: 
-      label: Logs
-      description: Optional relevant game log(s) or error message(s)
+      label: "Logs"
+      description: "Optional relevant game log(s) or error message(s)"
   - type: markdown
     attributes: 
       value: "Thanks for contributing!"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,9 +15,9 @@ body:
     attributes: 
       label: "Have you tried the following already?"
       options: 
-        - label: "Reloading the datapack (`/reload`)"
-        - label: "Restarting Minecraft"
-        - label: "using the lates version of GoBlocks"
+        - label: "reloading the datapack (`/reload`)"
+        - label: "restarting Minecraft"
+        - label: "using the latest version of GoBlocks"
   - type: textarea
     attributes: 
       label: Decsribe the bug
@@ -26,11 +26,11 @@ body:
   - type: textarea
     attributes: 
       label: Screenshots
-      description: Optional Screenshots that help describing the bug.
+      description: Optional screenshots that help describing the bug.
   - type: textarea
     attributes: 
       label: Logs
-      description: Optional relevant game log or error message 
+      description: Optional relevant game log(s) or error message(s)
   - type: markdown
     attributes: 
       value: "Thanks for contributing!"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,22 @@
+name: Feature Request
+description: Request a new feature
+title: "[Feature]"
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes: 
+      value: "Suggesting a feature does not guarantee that it will be added."
+  - type: dropdown
+    attributes: 
+      label: What type of request is this?
+      options:
+        - Changing or adding to an existing feature
+        - Completely new feature
+  - type: textarea
+    attributes:
+      label: Decsribe the feature
+      description: Describe the feature you'd like to see added to GoBlocks.
+      placeholder: "The feature:\n[...]\n\nIt would be cool/useful because:\n[...]"
+  - type: markdown
+    attributes:
+      value: "Thanks for your suggestion!"


### PR DESCRIPTION
added templates for github issues:

* `ISSUE_TEMPLATE/bug_report.yml` (auto-adding bug label)
![bug](https://user-images.githubusercontent.com/114934849/201986630-1e7006da-2388-497b-8a2e-6e12d8f062a0.jpg)

* `ISSUE_TEMPLATE/feature_request.yml` (auto-adding feature_request label)
![feature](https://user-images.githubusercontent.com/114934849/201986666-ba9f0713-27d4-4886-860b-03f9c1525151.jpg)
